### PR TITLE
LICENSE.txt のコピーライト年を 2026 に修正

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Studyplus inc.
+Copyright (c) 2026 Studyplus inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## 概要

OSS としての初公開年に合わせて、コピーライト年を 2025 から 2026 に修正しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)