### PR TITLE
Fix: Add safety check before removing skill directories

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -198,9 +198,11 @@ say "🌿 スキルファイルを更新しております..." \
     "🌿 Updating skill files..."
 
 # 削除が確定したスキルを個別に削除
-for s in "${removed_skills[@]}"; do
-  rm -rf "${SKILLS_DIR:?}/$s"
-done
+if [ ${#removed_skills[@]} -gt 0 ]; then
+  for s in "${removed_skills[@]}"; do
+    rm -rf "${SKILLS_DIR:?}/$s"
+  done
+fi
 
 # miko 管理スキルを個別に更新（プロテクト済みはスキップ）
 for s in "${latest_skills[@]}"; do


### PR DESCRIPTION
## Summary
Added a safety check to prevent iteration over an empty array when removing deprecated skills during the upgrade process.

## Key Changes
- Wrapped the skill removal loop with a condition that checks if the `removed_skills` array contains any elements before attempting to iterate
- This prevents potential issues when no skills need to be removed (empty array iteration)

## Implementation Details
The change adds `if [ ${#removed_skills[@]} -gt 0 ]; then` before the removal loop and closes it with `fi`, ensuring the loop only executes when there are actually skills to remove. This is a defensive programming practice that makes the script more robust and prevents unnecessary operations.

https://claude.ai/code/session_01DmpkFAbsRcEkudWFpcKRN9